### PR TITLE
fix description of "Ignore or include files in the given directories"

### DIFF
--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -46,7 +46,7 @@ export class SettingsTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName("Ignore or include files in the given directories")
-            .setDesc("Enable to ignore files in the given directories. Disable to only include files in the given filetypes")
+            .setDesc("Enable to ignore files in the given directories. Disable to only include files in the given directories")
             .addToggle(cb =>
                 cb.setValue(this.plugin.settings.ignoreDirectories)
                     .onChange(value => {


### PR DESCRIPTION
Fix the description shown in the image below:

![image](https://user-images.githubusercontent.com/8508804/159126391-a06ed40b-e0fb-45a0-838d-667291c9b65d.png)

Probably a leftover from a copy&paste. :)

Good job with this plugin, btw. I thing it's quite handy.