### PR TITLE
Reuse an empty leaf if available

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { App, CachedMetadata, getAllTags, iterateCacheRefs } from "obsidian";
+import { App, CachedMetadata, getAllTags, iterateCacheRefs, TFile } from "obsidian";
 
 export class Utils {
     private fileCache: CachedMetadata;
@@ -80,21 +80,15 @@ export class Utils {
             }
         });
 
-        const newPane = (() => {
-          if (app.workspace.getLeavesOfType("empty").length > 0) {
-            return false;
-          } else {
-            return true;
-          }
-        })();
 
         if (!fileIsAlreadyOpened) {
+            const newPane = app.workspace.getLeavesOfType("empty").length == 0;
             if (newPane) {
                 app.workspace.openLinkText(outputFileName, "/", true);
             } else {
                 const file = app.vault.getAbstractFileByPath(outputFileName);
 
-                if (file && file instanceof TFile) {
+                if (file instanceof TFile) {
                     await app.workspace.getLeavesOfType("empty")[0].openFile(file);
                 } else {
                     app.workspace.openLinkText(outputFileName, "/", true);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,7 +79,27 @@ export class Utils {
                 fileIsAlreadyOpened = true;
             }
         });
-        if (!fileIsAlreadyOpened)
-            app.workspace.openLinkText(outputFileName, "/", true);
+
+        const newPane = (() => {
+          if (app.workspace.getLeavesOfType("empty").length > 0) {
+            return false;
+          } else {
+            return true;
+          }
+        })();
+
+        if (!fileIsAlreadyOpened) {
+            if (newPane) {
+                app.workspace.openLinkText(outputFileName, "/", true);
+            } else {
+                const file = app.vault.getAbstractFileByPath(outputFileName);
+
+                if (file && file instanceof TFile) {
+                    await app.workspace.getLeavesOfType("empty")[0].openFile(file);
+                } else {
+                    app.workspace.openLinkText(outputFileName, "/", true);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Currently the plugin will always open its output in a new leaf, even if
the current leaf is empty. This implements a small quality of life
change that will open the output in an empty leaf and focus it, if one
is available.