### PR TITLE
Add option to include a header in the file

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { Utils } from './utils';
 
 export interface Settings {
 	outputFileName: string;
+	includeHeader: boolean;
 	disableWorkingLinks: boolean;
 	directoriesToIgnore: string[];
 	filesToIgnore: string[];
@@ -23,10 +24,12 @@ export interface Settings {
 	withoutTagsDirectoriesToIgnore: string[];
 	withoutTagsFilesToIgnore: string[];
 	withoutTagsOutputFileName: string;
+	withoutTagsIncludeHeader: boolean;
 	openOutputFile: boolean;
 }
 const DEFAULT_SETTINGS: Settings = {
 	outputFileName: "orphaned files output",
+	includeHeader: false,
 	disableWorkingLinks: false,
 	directoriesToIgnore: [],
 	filesToIgnore: [],
@@ -45,6 +48,7 @@ const DEFAULT_SETTINGS: Settings = {
 	withoutTagsDirectoriesToIgnore: [],
 	withoutTagsFilesToIgnore: [],
 	withoutTagsOutputFileName: "files without tags",
+	withoutTagsIncludeHeader: false,
 	openOutputFile: true,
 };
 
@@ -114,6 +118,8 @@ export default class FindOrphanedFilesPlugin extends Plugin {
 
 
 		let text = "";
+		if (this.settings.includeHeader)
+			text += "# " + this.settings.outputFileName + "\n";
 		let prefix: string;
 		if (this.settings.disableWorkingLinks)
 			prefix = "	";
@@ -217,7 +223,10 @@ export default class FindOrphanedFilesPlugin extends Plugin {
 			prefix = "	";
 		else
 			prefix = "";
-		const text = withoutFiles.map((file) => `${prefix}- [[${file.path}]]`).join("\n");
+		let text = "";
+		if (this.settings.withoutTagsIncludeHeader)
+			text += "# " + this.settings.withoutTagsOutputFileName + "\n";
+		text += withoutFiles.map((file) => `${prefix}- [[${file.path}]]`).join("\n");
 		Utils.writeAndOpenFile(this.app, outFileName, text, this.settings.openOutputFile);
 	}
 

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -48,6 +48,15 @@ export class SettingsTab extends PluginSettingTab {
             }).setValue(this.plugin.settings.outputFileName));
 
         new Setting(containerEl)
+            .setName('Include Header')
+            .setDesc('Include a header at the top of the file (same as the output file name)')
+            .addToggle(cb => cb.onChange(value => {
+                this.plugin.settings.includeHeader = value;
+                this.plugin.saveSettings();
+            }
+            ).setValue(this.plugin.settings.includeHeader));
+
+        new Setting(containerEl)
             .setName('Disable working links')
             .setDesc('Indent lines to disable the link and to clean up the graph view')
             .addToggle(cb => cb.onChange(value => {
@@ -227,6 +236,15 @@ export class SettingsTab extends PluginSettingTab {
                 }
                 this.plugin.saveSettings();
             }).setValue(this.plugin.settings.withoutTagsOutputFileName));
+
+        new Setting(containerEl)
+            .setName('Include Header')
+            .setDesc('Include a header at the top of the file (same as the output file name)')
+            .addToggle(cb => cb.onChange(value => {
+                this.plugin.settings.withoutTagsIncludeHeader = value;
+                this.plugin.saveSettings();
+            }
+            ).setValue(this.plugin.settings.withoutTagsIncludeHeader));
 
         new Setting(containerEl)
             .setName("Exclude files")


### PR DESCRIPTION
Some markdown converters (hugo/goldmark) will not convert a file that begins with a bullet list. This does not affect broken links because that file already has a preface paragraph.

I could make this a global thing, too, and have a single toggle that affects all three.