### PR TITLE
fix: cache==null case

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -277,6 +277,8 @@ export default class FindOrphanedFilesPlugin extends Plugin {
                 return;
             }
             const cache = this.app.metadataCache.getFileCache(mdFile);
+            if (!cache)
+                return;
             for (const ref of [
                 ...(cache.embeds ?? []),
                 ...(cache.links ?? []),


### PR DESCRIPTION
Fixes a case I encountered in my instance where `cache === null`. This made the plugin unusable for me.

```
Cannot read properties of null (reading 'embeds')
    at eval (VM280 plugin:find-unlinked-files:670:25)
    at Array.forEach (<anonymous>)
    at FindOrphanedFilesPlugin.findOrphanedFiles (VM280 plugin:find-unlinked-files:662:19)
    at Object.callback (VM280 plugin:find-unlinked-files:493:28)
    at sQ (app.js:1:2263551)
    at t.onChooseItem (app.js:1:2909281)
    at t.onChooseSuggestion (app.js:1:2164026)
    at t.selectSuggestion (app.js:1:2163431)
    at e.useSelectedItem (app.js:1:1240067)
    at e.onSuggestionClick (app.js:1:1239802)
```